### PR TITLE
feat: allow up to 0x3ff tiles for SNES

### DIFF
--- a/app/console-graphics.js
+++ b/app/console-graphics.js
@@ -1036,6 +1036,8 @@ const _extractTileInfoFromImageData = function (tileImageData, consoleGraphics, 
 
 
 export class Map {
+	static MAX_INDEX = 0xff;
+
 	width;
 	height;
 	tileset;
@@ -1054,7 +1056,7 @@ export class Map {
 	}
 
 	checkValidIndexes(){
-		return !this.mapTiles.find((mapTile) => this.tileset.tiles.indexOf(mapTile.tile)>0xff)
+		return !this.mapTiles.find((mapTile) => this.tileset.tiles.indexOf(mapTile.tile)>this.MAX_INDEX)
 	}
 	getMapTile(x, y) {
 		return this.mapTiles[y * this.width + x];

--- a/app/console-graphics.snes.js
+++ b/app/console-graphics.snes.js
@@ -82,6 +82,7 @@ class TileSNES extends Tile {
 
 class MapSNES extends Map{	
 	static ALLOW_ATTRIBUTES=true;
+	static MAX_INDEX=0x3ff;
 
 	export(){
 		const bytes=new Array(this.height);
@@ -92,7 +93,8 @@ class MapSNES extends Map{
 				const mapTile=this.mapTiles[index];
 				bytes[y][x * 2 + 0]=this.tileset.getTileIndex(this.mapTiles[index].tile);
 
-				let attributeByte=(this.tileset.getPaletteIndex(this.mapTiles[index].palette) & 0b00000111) << 2;
+				let attributeByte=this.tileset.getTileIndex(this.mapTiles[index].tile) >> 8;
+				attributeByte|=(this.tileset.getPaletteIndex(this.mapTiles[index].palette) & 0b00000111) << 2;
 				if(mapTile.flipX)
 					attributeByte|=0b01000000;
 				if(mapTile.flipY)

--- a/app/console-graphics.snes.js
+++ b/app/console-graphics.snes.js
@@ -65,10 +65,10 @@ class TileSNES extends Tile {
 			let byte3 = 0x00;
 			for (let x = 0; x < 8; x++) {
 				const colorIndex = this.getPixel(x, y);
-				byte0 |= (colorIndex & 0x01) << 7 - x;
-				byte1 |= (colorIndex >> 1) << 7 - x;
-				byte2 |= (colorIndex >> 2) << 7 - x;
-				byte3 |= (colorIndex >> 3) << 7 - x;
+				byte0 |= ((colorIndex >> 0) & 1) << 7 - x;
+				byte1 |= ((colorIndex >> 1) & 1) << 7 - x;
+				byte2 |= ((colorIndex >> 2) & 1) << 7 - x;
+				byte3 |= ((colorIndex >> 3) & 1) << 7 - x;
 			}
 			data[y * 2 + 0] = byte0;
 			data[y * 2 + 1] = byte1;
@@ -92,7 +92,7 @@ class MapSNES extends Map{
 				const mapTile=this.mapTiles[index];
 				bytes[y][x * 2 + 0]=this.tileset.getTileIndex(this.mapTiles[index].tile);
 
-				let attributeByte=this.tileset.getPaletteIndex(this.mapTiles[index].palette) & 0b00000111;
+				let attributeByte=(this.tileset.getPaletteIndex(this.mapTiles[index].palette) & 0b00000111) << 2;
 				if(mapTile.flipX)
 					attributeByte|=0b01000000;
 				if(mapTile.flipY)


### PR DESCRIPTION
SNES uses 10 bits for addressing tiles, so why not use them? Helpful for fullscreen images. Contains commit from #3 because it also modifies the attribute section, so merge #3 first (or merge this instead and drop #3).